### PR TITLE
Various copy edits and link fixes

### DIFF
--- a/_whatsnew/2025-10-06.adoc
+++ b/_whatsnew/2025-10-06.adoc
@@ -2,5 +2,5 @@
  
 The NetApp Console, built on the enhanced and restructured BlueXP foundation, provides centralized management of NetApp storage and NetApp Data Services across on-premises and cloud environments at enterprise grade—delivering real-time insights, faster workflows, and simplified administration, that is highly secure and compliant.
  
-For details on what has changed, see the link:https://docs.netapp.com/us-en/bluexp-relnotes/index.html[NetApp Console release notes].
+For details on what has changed, see the link:https://docs.netapp.com/us-en/console-relnotes/index.html[NetApp Console release notes].
  

--- a/concept-billing-preferences-terms.adoc
+++ b/concept-billing-preferences-terms.adoc
@@ -53,7 +53,7 @@ Billing preferences let you:
 * **PAYGO (Pay-As-You-Go)** — Flexible subscription billed by actual usage.
 * **Annual contract** — Fixed-term marketplace subscription.
 * **Auto renew** — Renews the contract automatically at expiration.
-* **Custom CVO configuration** — Advanced mode for mapping multiple subscriptions per hyperscaler.
+* **Custom CVO configuration** — Advanced mode for mapping multiple subscriptions per cloud provider.
 * **Direct license** — NetApp-managed license used before marketplace capacity.
 * **Hyperscaler** — AWS, Azure, or Google Cloud provider.
 * **Confirm changes dialog** — Appears before applying updates to prevent accidental billing changes.

--- a/concept-billing-preferences-terms.adoc
+++ b/concept-billing-preferences-terms.adoc
@@ -1,4 +1,4 @@
---
+---
 sidebar: sidebar
 permalink: concept-billing-preferences-terms.html
 keywords: license, licensing, licenses, subscriptions,

--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -61,7 +61,7 @@ Billing preferences are configured in the *Licenses and subscriptions* section o
 From there, you can:
 
 - Set billing preferences for your organization
-- Enable custom CVO configuration for advanced mapping
+- Enable advanced mapping of Cloud Volumes ONTAP instances to marketplace subscriptions
 - Edit or update marketplace subscription details
 
 == Fields
@@ -126,7 +126,7 @@ You can choose between billing modes depending on your organization’s procurem
 - *Auto-renew* — Enables automatic continuation of licenses or marketplace contracts when they expire.  
   Disabling this option requires manual renewal to prevent service interruption.
 
-- *Custom CVO configuration* — Allows mapping multiple marketplace subscriptions to a single hyperscaler.  
+- *Custom Cloud Volumes ONTAP configuration* — Allows mapping multiple marketplace subscriptions to a single hyperscaler.  
   This might be useful when different business units or projects require distinct billing accounts within the same cloud environment.
 
 

--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -16,7 +16,7 @@ summary: "Learn how licenses and subscriptions define how NetApp Console manages
 Billing preferences allows you to determine how you handle payments and renewal behavior for your active licenses and subscriptions. 
 You can apply these preferences globally, so they affect all billing relationships, or at the individual subscription level when a specific contract requires its own configuration.
 
-- *Marketplace subscriptions* correspond to cloud marketplace contracts (AWS, Azure, or Google Cloud) where usage charges are through a hyperscaler account.  
+- *Marketplace subscriptions* correspond to cloud marketplace contracts (AWS, Azure, or Google Cloud) where usage charges are through a cloud provider account  
 - *Direct licenses* represent licenses purchased directly from NetApp, managed in NetApp Console through license keys, invoice recipients, and renewal options.  
 
 You can configure how your organization allocates and pays for services depending on your procurement model.
@@ -126,7 +126,7 @@ You can choose between billing modes depending on your organization’s procurem
 - *Auto-renew* — Enables automatic continuation of licenses or marketplace contracts when they expire.  
   Disabling this option requires manual renewal to prevent service interruption.
 
-- *Custom Cloud Volumes ONTAP configuration* — Allows mapping multiple marketplace subscriptions to a single hyperscaler.  
+- *Custom Cloud Volumes ONTAP configuration* — Allows mapping multiple marketplace subscriptions to a cloud provider.  
   This might be useful when different business units or projects require distinct billing accounts within the same cloud environment.
 
 
@@ -146,7 +146,7 @@ The following examples illustrate how different billing setups align with common
 
 For instance, consider an organization that combines both direct NetApp licenses and marketplace subscriptions.  
 A typical configuration would set *NetApp licenses first* as the default billing mode to use prepaid capacity before marketplace billing.  
-Then, under *Custom CVO configuration*, each hyperscaler (AWS, Azure, Google Cloud) would be assigned its corresponding subscription ID.  
+Then, under *Custom CVO configuration*, each cloud provider (AWS, Azure, Google Cloud) would be assigned its corresponding subscription ID.  
 
 After saving these settings, administrators can review the mappings under *Licenses and subscriptions* to verify that each service points to the correct account.  
 For additional validation, they can compare usage data in NetApp Console against cloud billing dashboards and adjust cost center tags or contacts as needed to maintain reporting consistency.

--- a/concept-licenses-subscriptions.adoc
+++ b/concept-licenses-subscriptions.adoc
@@ -41,7 +41,7 @@ You can manage licenses and subscriptions for the following services in the Cons
 * https://docs.netapp.com/us-en/data-services-backup-recovery/index.html[Backup and Recovery^]
 * https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/index.html[Cloud Volumes ONTAP^]
 * https://docs.netapp.com/us-en/data-services-disaster-recovery/index.html[Disaster Recovery^] (BYOL only)
-* https://docs.netapp.com/us-en/data-services-ransomware-protection/index.html[Ransomware Resilience^]
+* https://docs.netapp.com/us-en/data-services-ransomware-resilience/index.html[Ransomware Resilience^]
 * https://docs.netapp.com/us-en/data-services-cloud-tiering/index.html[Cloud Tiering^]
 
 

--- a/concept-licenses-subscriptions.adoc
+++ b/concept-licenses-subscriptions.adoc
@@ -38,11 +38,11 @@ https://docs.netapp.com/us-en/console-setup-admin/task-adding-nss-accounts.html[
 
 You can manage licenses and subscriptions for the following services in the Console:
 
-* https://docs.netapp.com/us-en/console-backup-recovery/index.html[Backup and Recovery^]
-* https://docs.netapp.com/us-en/console-cloud-volumes-ontap/index.html[Cloud Volumes ONTAP^]
-* https://docs.netapp.com/us-en/console-disaster-recovery/index.html[Disaster Recovery^] (BYOL only)
-* https://docs.netapp.com/us-en/console-ransomware-protection/index.html[Ransomware Resilience^]
-* https://docs.netapp.com/us-en/console-tiering/index.html[Cloud Tiering^]
+* https://docs.netapp.com/us-en/data-services-backup-recovery/index.html[Backup and Recovery^]
+* https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/index.html[Cloud Volumes ONTAP^]
+* https://docs.netapp.com/us-en/data-services-disaster-recovery/index.html[Disaster Recovery^] (BYOL only)
+* https://docs.netapp.com/us-en/data-services-ransomware-protection/index.html[Ransomware Resilience^]
+* https://docs.netapp.com/us-en/data-services-cloud-tiering/index.html[Cloud Tiering^]
 
 
 

--- a/project.yml
+++ b/project.yml
@@ -16,7 +16,7 @@ sidebar:
           url: /whats-new.html
     - title: Get started
       entries:
-      - title: Learn about 
+      - title: Learn about licenses and subscriptions
         url: /concept-licenses-subscriptions.html
     - title: Use licenses and subscriptions
       entries:

--- a/task-homepage.adoc
+++ b/task-homepage.adoc
@@ -33,8 +33,8 @@ For example, administrators tasked with managing Cloud Volumes ONTAP resources c
 
 NOTE: Although you can update and remove licenses from the dashboard, you cannot add a new license or subscription.
 
-link:task-manage-data-services-licenses.html[Learn more about managing licenses^].
-link:task-manage-subscriptions.html[Learn more about managing subscriptions^].
+link:task-manage-data-services-licenses.html[Learn more about managing licenses].
+link:task-manage-subscriptions.html[Learn more about managing subscriptions].
 
 .Steps
 
@@ -60,7 +60,7 @@ You cannot add new licenses or subscriptions from the *Overview* page for a spec
 
 + 
 
-link:task-data-services-licenses.html[Learn more about managing licenses.]
+link:task-manage-data-services-licenses.html[Learn more about managing licenses.]
 link:task-manage-subscriptions.html[Learn more about managing subscriptions.]
 
 === Resolve license or subscription issues
@@ -79,5 +79,5 @@ You can view license and subscription issues that need to be resolved. Issues in
 
 + 
 
-link:task-manage-data-services-licenses.html[Learn more about managing licenses^].
-link:task-manage-subscriptions.html[Learn more about managing subscriptions^].
+link:task-manage-data-services-licenses.html[Learn more about managing licenses].
+link:task-manage-subscriptions.html[Learn more about managing subscriptions].

--- a/task-manage-billing-preferences.adoc
+++ b/task-manage-billing-preferences.adoc
@@ -49,23 +49,23 @@ NetApp Console updates the billing mappings. Future service charges and renewals
 NOTE: Changing the billing mode redistributes how service charges are applied. New Cloud Volumes ONTAP (CVO) instances automatically inherit the selected configuration.
 
 
-== Enable custom CVO configuration
+== Enable custom Cloud Volumes ONTAP configuration
 
-Custom CVO configuration allows you to assign multiple marketplace subscriptions under the same hyperscaler.  
+You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same hyperscaler. 
 Use this mode if your organization maintains different billing accounts for separate business units or environments.
 
 .Steps
 
 . In NetApp Console, select *Administration > Licenses and subscriptions*.
 . Select *Billing preferences*.
-. Under **Marketplace subscripitions**, enable *Custom CVO configuration*.
+. Under **Marketplace subscriptions**, enable *Custom CVO configuration*.
 . Select **Save changes**.
 
 .Result
 
 You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same hyperscaler.
 
-WARNING: After this is enabled, custom CVO configuration cannot be reverted from the **Billing preferences**. Disabling this resets all CVO billing to the standard billing configuration for your data services.
+WARNING: After this is enabled, custom Cloud Volumes ONTAP configuration cannot be reverted from the **Billing preferences**. Disabling this resets all Cloud Volumes ONTAP billing to the standard billing configuration for your data services.
 
 
 == Edit marketplace configuration
@@ -109,5 +109,5 @@ Every update to billing preferences requires confirmation to prevent accidental 
 
 .Result
 
-CVO instances return to the default standard billing method used for the other data services.
+Cloud Volumes ONTAP instances return to the default standard billing method used for the other data services.
 

--- a/task-manage-billing-preferences.adoc
+++ b/task-manage-billing-preferences.adoc
@@ -35,8 +35,8 @@ You can select how the Console applies usage charges across billing sources. Thi
 ** *NetApp licenses first* – Use NetApp licenses first, then marketplace subscriptions for additional usage.
 ** *Marketplace subscriptions only* – Bill all usage directly through marketplace subscriptions.
 +
-. Under *Marketplace subscriptions*, select the subscription for each hyperscaler (AWS, Azure, and Google Cloud).
-. If you use multiple subscriptions under a single hyperscaler, enable *Custom CVO configuration*.
+. Under *Marketplace subscriptions*, select the subscription for each cloud provider (AWS, Azure, and Google Cloud).
+. If you use multiple subscriptions under a single cloud provider, enable *Custom CVO configuration*.
 . (Optional) Update *Invoice contacts* and *Notification contacts*.
 . (Optional) Enter a *Cost center tag* to associate billing with internal accounting codes.
 . Select *Save changes*.
@@ -51,7 +51,7 @@ NOTE: Changing the billing mode redistributes how service charges are applied. N
 
 == Enable custom Cloud Volumes ONTAP configuration
 
-You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same hyperscaler. 
+You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same cloud provider. 
 Use this mode if your organization maintains different billing accounts for separate business units or environments.
 
 .Steps
@@ -63,7 +63,7 @@ Use this mode if your organization maintains different billing accounts for sepa
 
 .Result
 
-You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same hyperscaler.
+You can now assign specific marketplace subscriptions to individual Cloud Volumes ONTAP instances under the same cloud provider.
 
 WARNING: After this is enabled, custom Cloud Volumes ONTAP configuration cannot be reverted from the **Billing preferences**. Disabling this resets all Cloud Volumes ONTAP billing to the standard billing configuration for your data services.
 

--- a/task-manage-data-services-licenses.adoc
+++ b/task-manage-data-services-licenses.adoc
@@ -22,7 +22,7 @@ The instructions on this page provide information that applies to each service. 
 * https://docs.netapp.com/us-en/data-services-backup-recovery/br-start-licensing.html[Set up licensing for NetApp Backup and Recovery^]
 * https://docs.netapp.com/us-en/data-services-disaster-recovery/get-started/dr-licensing.html[Set up licensing for NetApp Disaster Recovery^]
 * https://docs.netapp.com/us-en/data-services-ransomware-resilience/rp-start-licenses.html[Set up licensing for NetApp Ransomware Resilience^]
-* https://docs.netapp.com/us-en/data-services-tiering/task-licensing-cloud-tiering.html[Set up licensing for NetApp Cloud Tiering^]
+* https://docs.netapp.com/us-en/data-services-cloud-tiering/task-licensing-cloud-tiering.html[Set up licensing for NetApp Cloud Tiering^]
 * https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/concept-licensing.html[Set up licensing for Cloud Volumes ONTAP^]
 
 

--- a/task-manage-data-services-licenses.adoc
+++ b/task-manage-data-services-licenses.adoc
@@ -19,11 +19,11 @@ NOTE: The *Direct licenses* page lists all licenses. If you want license details
 
 The instructions on this page provide information that applies to each service. For more specific information about the licensing for these services, refer to the following pages:
 
-* https://docs.netapp.com/us-en/console-backup-recovery/br-start-licensing.html[Set up licensing for NetApp Backup and Recovery^]
-* https://docs.netapp.com/us-en/console-disaster-recovery/get-started/dr-licensing.html[Set up licensing for NetApp Disaster Recovery^]
-* https://docs.netapp.com/us-en/console-ransomware-resilience/rp-start-licenses.html[Set up licensing for NetApp Ransomware Resilience^]
-* https://docs.netapp.com/us-en/console-tiering/task-licensing-cloud-tiering.html[Set up licensing for NetApp Cloud Tiering^]
-* https://docs.netapp.com/us-en/console-cloud-volumes-ontap/concept-licensing.html[Set up licensing for Cloud Volumes ONTAP^]
+* https://docs.netapp.com/us-en/data-services-backup-recovery/br-start-licensing.html[Set up licensing for NetApp Backup and Recovery^]
+* https://docs.netapp.com/us-en/data-services-disaster-recovery/get-started/dr-licensing.html[Set up licensing for NetApp Disaster Recovery^]
+* https://docs.netapp.com/us-en/data-services-ransomware-resilience/rp-start-licenses.html[Set up licensing for NetApp Ransomware Resilience^]
+* https://docs.netapp.com/us-en/data-services-tiering/task-licensing-cloud-tiering.html[Set up licensing for NetApp Cloud Tiering^]
+* https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/concept-licensing.html[Set up licensing for Cloud Volumes ONTAP^]
 
 
 == Obtain a license file

--- a/task-manage-node-based-licenses.adoc
+++ b/task-manage-node-based-licenses.adoc
@@ -10,7 +10,7 @@ summary: Manage your node-based licenses in the Console to ensure that each Clou
 :nofooter:
 :icons: font
 :linkattrs:
-:imagesdir: https://docs.netapp.com/us-en/console-cloud-volumes-ontap/media/
+:imagesdir: https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/media/
 
 [.lead]
-include::https://raw.githubusercontent.com/NetAppDocs/console-cloud-volumes-ontap/main/task-manage-node-licenses.adoc[lines=15..-1]
+include::https://raw.githubusercontent.com/NetAppDocs/storage-management-cloud-volumes-ontap/main/task-manage-node-licenses.adoc[lines=15..-1]

--- a/task-manage-private-aws.adoc
+++ b/task-manage-private-aws.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-manage-private-aws.html
 keywords: activate, license, licensing, install, request capacity, link subscription, keystone flex, bluexp, netapp console, marketplace, aws
-summary: Manage your general and Hyperscaler specific, end-to-end Private Offer Process and NetApp Intelligent Services acceptance and activation guides for AWS, Azure, and Google Cloud.
+summary: Accept a Marketplace private offer for the NetApp Console in the AWS console and configure AWS credentials in the Console.
 ---
 
 = Accept and configure an AWS Marketplace private offer for the NetApp Console
@@ -102,7 +102,7 @@ For contract listings, click *View purchase options* to display the offer, then 
 . Review the marketplace subscription options. 
 . Select the marketplace subscription you want to bill. This only applies when there is more than one option. 
 . Select **Save changes**.
-. Repeat these steps as needed, if there are multiple subscriptions across multiple hyperscalers. 
+. Repeat these steps as needed, if there are multiple subscriptions across multiple cloud providers. 
 
 
 For more information on marketplace subscriptions and direct licenses billing, see the link:https://docs.netapp.com/us-en/console-licenses-subscriptions/concept-billing-preferences.html[Billing preferences documentation].

--- a/task-manage-private-azure.adoc
+++ b/task-manage-private-azure.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-manage-private-azure.html
 keywords: activate, license, licensing, install, request capacity, link subscription, keystone flex, bluexp, netapp console, marketplace, azure
-summary: Manage your general and Hyperscaler specific, end-to-end Private Offer Process and NetApp Intelligent Services acceptance and activation guides for AWS, Azure, and Google Cloud.
+summary: Accept and subscribe to a Marketplace private offer for the NetApp Console in the Azure portal. Configure Azure credentials in the Console.
 ---
 
 = Accept and activate an Azure private offer for the NetApp Console
@@ -91,7 +91,7 @@ The subscription displays as *Pending configuration*. Select it to continue conf
 +
 [NOTE]
 ====
-* This replacement option is limited to a single Console account.  
+* This replacement option is limited to a single Console organization.  
 * To associate multiple Console accounts with the same Marketplace subscription, configure the additional accounts manually.  
 ====
 
@@ -101,6 +101,6 @@ The subscription displays as *Pending configuration*. Select it to continue conf
 . Review the marketplace subscription options. 
 . Select the marketplace subscription you want to bill. This only applies when there is more than one option. 
 . Select **Save changes**.
-. Repeat these steps as needed, if there are multiple subscriptions across multiple hyperscalers. 
+. Repeat these steps as needed, if there are multiple subscriptions across multiple cloud providers. 
 
 For more information on marketplace subscriptions and direct licenses billing, see the link:https://docs.netapp.com/us-en/console-licenses-subscriptions/concept-billing-preferences.html[Billing preferences documentation].

--- a/task-manage-private-google-cloud.adoc
+++ b/task-manage-private-google-cloud.adoc
@@ -10,6 +10,7 @@ summary: Accept a Marketplace private offer for the NetApp Console listing in th
 :nofooter:
 :icons: font
 :linkattrs:
+:imagesdir: ./media/
 
 [.lead]
 Accept a Marketplace private offer for the NetApp Console listing in the Google Cloud console. Configure Google Cloud credentials in the Console.

--- a/task-manage-private-google-cloud.adoc
+++ b/task-manage-private-google-cloud.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-manage-private-google-cloud.html
 keywords: activate, license, licensing, install, request capacity, link subscription, keystone flex, bluexp, netapp console, marketplace, google cloud
-summary: Manage your general and Hyperscaler specific, end-to-end Private Offer Process and NetApp Intelligent Services acceptance and activation guides for AWS, Azure, and Google Cloud.
+summary: Accept a Marketplace private offer for the NetApp Console listing in the Google Cloud console. Configure Google Cloud credentials in the Console.
 ---
 
 = Accept and configure a Google Cloud private offer for the NetApp Console
@@ -79,7 +79,7 @@ Review the plan details, term, and pricing carefully. If anything is incorrect, 
 . Review the marketplace subscription options. 
 . Select the marketplace subscription you want to bill. This only applies when there is more than one option. 
 . Select **Save changes**.
-. Repeat these steps as needed, if there are multiple subscriptions across multiple hyperscalers. 
+. Repeat these steps as needed, if there are multiple subscriptions across multiple cloud providers. 
 
 
 For more information on marketplace subscriptions and direct licenses billing, see the link:https://docs.netapp.com/us-en/console-licenses-subscriptions/concept-billing-preferences.html[Billing preferences documentation].

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -56,7 +56,7 @@ Email notifications are now supported with the BlueXP digital wallet.
 
 If you configure your notification settings, you can receive email notifications when your BYOL licenses are about to expire (a "Warning" notification) or if they have already expired (an "Error" notification).
 
-https://docs.netapp.com/us-en/consosetup-admin/task-monitor-cm-operations.html[Learn how to set up email notifications^]
+https://docs.netapp.com/us-en/console-setup-admin/task-monitor-cm-operations.html[Learn how to set up email notifications^]
 
 === Licensed capacity for marketplace subscriptions
 


### PR DESCRIPTION
This pull request focuses on updating terminology and documentation links to improve clarity and consistency regarding billing preferences, subscriptions, and license management in the NetApp Console. The main changes replace "hyperscaler" with "cloud provider," update documentation links to new locations, and clarify descriptions and instructions across several files.

**Terminology updates:**

* Replaced references to "hyperscaler" with "cloud provider" in billing preferences, configuration instructions, and user guides to ensure consistent terminology across documentation. [[1]](diffhunk://#diff-f56d5ec804525f34677e66942f79f023a263ff49670d8f7636358fc94db505c3L56-R56) [[2]](diffhunk://#diff-349e27b80799d6425677747f1130cfabeb395524d4ca2174642a65f524c0391bL19-R19) [[3]](diffhunk://#diff-349e27b80799d6425677747f1130cfabeb395524d4ca2174642a65f524c0391bL129-R129) [[4]](diffhunk://#diff-349e27b80799d6425677747f1130cfabeb395524d4ca2174642a65f524c0391bL149-R149) [[5]](diffhunk://#diff-91a0c97671f572f17d5030693ed5a971ecbc1bdad8b0ed3c38a7f1be714b9715L38-R39) [[6]](diffhunk://#diff-91a0c97671f572f17d5030693ed5a971ecbc1bdad8b0ed3c38a7f1be714b9715L52-R68) [[7]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL105-R105) [[8]](diffhunk://#diff-6474d2213e9d0cbb7d95ed0627e9ae60f8fc92fb0451da4a50965d13d3336f98L104-R104) [[9]](diffhunk://#diff-04a70e75b536e111503aef3eaf3ee424d2b7ad0436d732f8a0fe079487fb0d0aL82-R83)

**Documentation link updates:**

* Updated internal and external documentation links to point to new or reorganized locations for backup, recovery, tiering, ransomware resilience, disaster recovery, and Cloud Volumes ONTAP services. [[1]](diffhunk://#diff-2dc3d1ec78d37412dbcd4ab6203a06a714b8e06f28836292c870fba4e4994b7fL41-R45) [[2]](diffhunk://#diff-c6cb82f9c01201cd91c65c5d0eae5a5e75aa7703ad7d7c042c11b8f353c53ea1L22-R26) [[3]](diffhunk://#diff-c5332a41d8f9c656f841355e924c9edf84bd654e0e442b942e4f680221efcacaL13-R16)
* Changed release notes link from BlueXP to NetApp Console for improved accuracy.

**Clarification of descriptions and instructions:**

* Revised summary and instructional text in private offer guides for AWS, Azure, and Google Cloud to clarify the process and scope, including replacing "Console account" with "Console organization" where appropriate. [[1]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL5-R5) [[2]](diffhunk://#diff-6474d2213e9d0cbb7d95ed0627e9ae60f8fc92fb0451da4a50965d13d3336f98L5-R5) [[3]](diffhunk://#diff-6474d2213e9d0cbb7d95ed0627e9ae60f8fc92fb0451da4a50965d13d3336f98L94-R94) [[4]](diffhunk://#diff-04a70e75b536e111503aef3eaf3ee424d2b7ad0436d732f8a0fe079487fb0d0aL5-R13)
* Improved descriptions for custom billing configuration, mapping, and renewal behavior to better reflect current functionality. [[1]](diffhunk://#diff-349e27b80799d6425677747f1130cfabeb395524d4ca2174642a65f524c0391bL64-R64) [[2]](diffhunk://#diff-91a0c97671f572f17d5030693ed5a971ecbc1bdad8b0ed3c38a7f1be714b9715L112-R112)

**Navigation and UI updates:**

* Updated navigation titles in `project.yml` to clarify the purpose of the "Learn about licenses and subscriptions" section.

**Link formatting improvements:**

* Removed unnecessary caret symbols (`^`) from documentation links to streamline user experience. [[1]](diffhunk://#diff-663d3842ebff7fa4854e2217f7c949375b0aadb6caa45542026ef630d15720d0L36-R37) [[2]](diffhunk://#diff-663d3842ebff7fa4854e2217f7c949375b0aadb6caa45542026ef630d15720d0L63-R63) [[3]](diffhunk://#diff-663d3842ebff7fa4854e2217f7c949375b0aadb6caa45542026ef630d15720d0L82-R83)