### PR TITLE
Fixing customer-reported issue

### DIFF
--- a/task-manage-private-aws.adoc
+++ b/task-manage-private-aws.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task-manage-private-aws.html
 keywords: activate, license, licensing, install, request capacity, link subscription, keystone flex, bluexp, netapp console, marketplace, aws
-summary: Accept a Marketplace private offer for the NetApp Console in the AWS console and configure AWS credentials in the Console.
+summary: Accept a Marketplace private offer for the NetApp Console in the AWS Marketplace Portal and configure AWS credentials in the Console.
 ---
 
 = Accept and configure an AWS Marketplace private offer for the NetApp Console
@@ -13,7 +13,7 @@ summary: Accept a Marketplace private offer for the NetApp Console in the AWS co
 :imagesdir: ./media/
 
 [.lead]
-Accept a Marketplace private offer for the NetApp Console in the AWS console and configure AWS credentials in the Console.
+Accept a Marketplace private offer for the NetApp Console in the AWS Marketplace Portal and configure AWS credentials in the Console.
 
 .Before you begin
 
@@ -22,7 +22,7 @@ Accept a Marketplace private offer for the NetApp Console in the AWS console and
 ** link:https://docs.aws.amazon.com/marketplace/latest/buyerguide/buyer-private-offers-subscribing.html[Viewing and subscribing to a private offer]  
 ** link:https://docs.aws.amazon.com/marketplace/latest/buyerguide/buyer-iam-users-groups-policies.html[Buyer permissions validation]
 
-== Accept the private offer in the AWS console
+== Accept the private offer in the AWS Marketplace Portal
 
 Completing the subscription assignment in the Console is required to activate the purchase and apply discounted pricing.  
 
@@ -82,12 +82,12 @@ If you accepted the offer but did not complete registration, return to the produ
 For contract listings, click *View purchase options* to display the offer, then select *Set up your account*.  
 ====
 
-. Sign in at https://console.netapp.com with your Console account.  
+. Sign in at https://console.netapp.com.  
 
 . After logging in, navigate to https://console.netapp.com/licenses/overview. You are prompted to:  
 .. Enter a *Display name* for the Marketplace subscription.  
-.. Select the Console *Accounts* with access to the subscription.  
-.. [Optional] Enable *Replace existing subscription* to overwrite an existing subscription for one account.  
+.. Select the Console *Organization* with access to the subscription.  
+.. [Optional] Enable *Replace existing subscription* to overwrite an existing subscription for an organization.  
 +
 [NOTE]
 ====

--- a/task-manage-private-azure.adoc
+++ b/task-manage-private-azure.adoc
@@ -86,8 +86,8 @@ The subscription displays as *Pending configuration*. Select it to continue conf
 . After logging in, you are redirected to https://console.netapp.com/licenses/overview.  
    You are prompted to:  
 .. Enter a *Display name* for the Marketplace Subscription.  
-.. Select the Console *Accounts* that should have access to this subscription.  
-.. Optionally, you can enable *Replace existing subscription* to automatically replace an existing Marketplace subscription in one Console account.  
+.. Select the Console *Organizations* that should have access to this subscription.  
+.. Optionally, you can enable *Replace existing subscription* to automatically replace an existing Marketplace subscription in one Console organization.  
 +
 [NOTE]
 ====

--- a/task-manage-private-google-cloud.adoc
+++ b/task-manage-private-google-cloud.adoc
@@ -65,8 +65,8 @@ Review the plan details, term, and pricing carefully. If anything is incorrect, 
 . You are redirected to `https://console.netapp.com` and prompted to sign in.
 . After logging in, you are redirected to `https://console.netapp.com/licenses/overview`. A popup is displayed where you must:
 .. Enter a display name for the *SaaS Marketplace Subscription*.
-.. Select the Console **Accounts** that should have access to the subscription.
-.. Optionally, you can enable **Replace existing subscription** if you want to automatically replace an existing Marketplace subscription in one Console account.
+.. Select the Console *Organizations* that should have access to the subscription.
+.. Optionally, you can enable **Replace existing subscription** if you want to automatically replace an existing Marketplace subscription in one Console organization.
 +
 [NOTE]
 ====


### PR DESCRIPTION
This pull request updates documentation to clarify terminology and improve consistency in how access to Marketplace subscriptions is described across AWS, Azure, and Google Cloud. The changes primarily replace references to "Accounts" with "Organizations" and update instructions to refer to the correct portals.

Terminology and portal updates:

* Updated all occurrences of "AWS console" to "AWS Marketplace Portal" in both summary and section headings in `task-manage-private-aws.adoc` to accurately reflect the correct portal for accepting private offers. [[1]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL5-R5) [[2]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL16-R16) [[3]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL25-R25)
* Changed instructions to select Console "Organization" instead of "Accounts" when assigning access to a subscription in AWS, Azure, and Google Cloud documentation files, ensuring consistent terminology. [[1]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL85-R90) [[2]](diffhunk://#diff-6474d2213e9d0cbb7d95ed0627e9ae60f8fc92fb0451da4a50965d13d3336f98L89-R90) [[3]](diffhunk://#diff-04a70e75b536e111503aef3eaf3ee424d2b7ad0436d732f8a0fe079487fb0d0aL68-R69)

Access assignment improvements:

* Clarified that the "Replace existing subscription" option now applies to organizations rather than accounts, reflecting updated functionality in the subscription process across all cloud provider documentation. [[1]](diffhunk://#diff-c0e9b3ce0fd369d5e58dfdf6ab270c65632caf8773e3124f7332340712b66f1fL85-R90) [[2]](diffhunk://#diff-6474d2213e9d0cbb7d95ed0627e9ae60f8fc92fb0451da4a50965d13d3336f98L89-R90) [[3]](diffhunk://#diff-04a70e75b536e111503aef3eaf3ee424d2b7ad0436d732f8a0fe079487fb0d0aL68-R69)