### PR TITLE
Sync internal main documentation updates

### DIFF
--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -64,6 +64,25 @@ From there, you can:
 - Enable advanced mapping of Cloud Volumes ONTAP instances to marketplace subscriptions
 - Edit or update marketplace subscription details
 
+== Flexible billing for Cloud Volumes ONTAP and data services in AWS
+
+In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS Marketplace subscriptions. Due to AWS Enterprise Discount Program (EDP) changes, NetApp recommends using the standalone Cloud Volumes ONTAP subscription for Cloud Volumes ONTAP capacity billing and the NetApp Intelligent Services (NIS) subscription for NetApp data services billing. 
+
+If both a standalone Cloud Volumes ONTAP subscription and the NetApp Intelligent Services (NIS) subscription are available for your AWS account, you can use Billing preferences to select which subscription is used for Cloud Volumes ONTAP capacity billing.
+
+NOTE: Billing behavior depends on whether you have existing Cloud Volumes ONTAP systems already running and billed through NIS, or you are deploying new systems after adding the standalone Cloud Volumes ONTAP subscription. For existing systems, adding the standalone subscription does not change billing unless you update *Billing preferences*. For new deployments created after the standalone subscription is available, the standalone subscription is used by default for Cloud Volumes ONTAP capacity billing (Essentials/Freemium), unless you override it in *Billing preferences*.
+
+- Standalone Cloud Volumes ONTAP subscription (recommended): Cloud Volumes ONTAP capacity (Essentials/Freemium)
+- NetApp Intelligent Services (NIS) subscription: NetApp data services (and Cloud Volumes ONTAP Professional)
+
+The standalone Cloud Volumes ONTAP subscription supports only capacity-based Essentials and Freemium packages. The Professional package is not supported and continues to bill through NIS. If you have only the standalone subscription associated, you can deploy Cloud Volumes ONTAP using Essentials, but configuring Backup and Recovery requires a different subscription.
+
+*Where to configure it*
+
+You associate AWS marketplace subscriptions under *Administration > Licenses and subscriptions > Marketplace subscriptions*, and you choose the Marketplace subscription used for Cloud Volumes ONTAP capacity billing under *Administration > Licenses and subscriptions > Billing preferences*. You can verify charging details using Cloud Volumes ONTAP usage reports.
+
+NOTE: No duplicate metering occurs when you use multiple subscription types or migrate between listings.
+
 == Fields
 
 Billing fields store metadata about how each license or subscription is billed.  

--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -66,7 +66,7 @@ From there, you can:
 
 == Flexible billing for Cloud Volumes ONTAP and data services in AWS
 
-In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS Marketplace subscriptions. For details on AWS Enterprise Discount Program (EDP) changes and recommendations, see the link:https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/whats-new.html#flexible-billing-for-cloud-volumes-ontap-and-data-services-in-aws[Cloud Volumes ONTAP release notes]. 
+In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS marketplace subscriptions. For details on AWS Enterprise Discount Program (EDP) changes and recommendations, see the link:https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/whats-new.html#flexible-billing-for-cloud-volumes-ontap-and-data-services-in-aws[Cloud Volumes ONTAP release notes]. 
 
 If both a standalone Cloud Volumes ONTAP subscription and the NetApp Intelligent Services (NIS) subscription are available for your AWS account, you can use Billing preferences to select which subscription is used for Cloud Volumes ONTAP capacity billing.
 
@@ -77,9 +77,9 @@ NOTE: Billing behavior depends on whether you have existing Cloud Volumes ONTAP 
 
 The standalone Cloud Volumes ONTAP subscription supports only capacity-based Essentials and Freemium packages. The Professional package is not supported and continues to bill through NIS. If you have only the standalone subscription associated, you can deploy Cloud Volumes ONTAP using Essentials, but configuring Backup and Recovery requires a different subscription.
 
-*Where to configure it*
+=== Where to configure it
 
-You associate AWS marketplace subscriptions under *Administration > Licenses and subscriptions > Marketplace subscriptions*, and you choose the Marketplace subscription used for Cloud Volumes ONTAP capacity billing under *Administration > Licenses and subscriptions > Billing preferences*. You can verify charging details using Cloud Volumes ONTAP usage reports.
+You associate AWS marketplace subscriptions under *Administration > Licenses and subscriptions > Marketplace subscriptions*, and you choose the marketplace subscription used for Cloud Volumes ONTAP capacity billing under *Administration > Licenses and subscriptions > Billing preferences*. You can verify charging details using Cloud Volumes ONTAP usage reports.
 
 NOTE: No duplicate metering occurs when you use multiple subscription types or migrate between listings.
 
@@ -96,7 +96,7 @@ They also control how renewals, regional assignments, and billing accounts are m
 
 - *Marketplace provider* — Identifies the cloud platform where billing is handled.  
   The provider determines the supported features, contract types, and renewal rules.  
-  For example, AWS Marketplace subscriptions use account-based billing, while Azure may support both account and tenant-based models.
+  For example, AWS marketplace subscriptions use account-based billing, while Azure may support both account and tenant-based models.
 
 - *Billing account or subscription ID* — Specifies the unique identifier for the account used to process charges.  
   This ensures that usage data is billed to the correct cloud billing profile.  

--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -66,7 +66,7 @@ From there, you can:
 
 == Flexible billing for Cloud Volumes ONTAP and data services in AWS
 
-In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS Marketplace subscriptions. Due to AWS Enterprise Discount Program (EDP) changes, NetApp recommends using the standalone Cloud Volumes ONTAP subscription for Cloud Volumes ONTAP capacity billing and the NetApp Intelligent Services (NIS) subscription for NetApp data services billing. 
+In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS Marketplace subscriptions. For details on AWS Enterprise Discount Program (EDP) changes and recommendations, see the link:https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/whats-new.html#flexible-billing-for-cloud-volumes-ontap-and-data-services-in-aws[Cloud Volumes ONTAP release notes]. 
 
 If both a standalone Cloud Volumes ONTAP subscription and the NetApp Intelligent Services (NIS) subscription are available for your AWS account, you can use Billing preferences to select which subscription is used for Cloud Volumes ONTAP capacity billing.
 

--- a/concept-billing-preferences.adoc
+++ b/concept-billing-preferences.adoc
@@ -68,7 +68,7 @@ From there, you can:
 
 In AWS, Cloud Volumes ONTAP capacity and NetApp data services can be billed through different AWS marketplace subscriptions. For details on AWS Enterprise Discount Program (EDP) changes and recommendations, see the link:https://docs.netapp.com/us-en/storage-management-cloud-volumes-ontap/whats-new.html#flexible-billing-for-cloud-volumes-ontap-and-data-services-in-aws[Cloud Volumes ONTAP release notes]. 
 
-If both a standalone Cloud Volumes ONTAP subscription and the NetApp Intelligent Services (NIS) subscription are available for your AWS account, you can use Billing preferences to select which subscription is used for Cloud Volumes ONTAP capacity billing.
+If both a standalone Cloud Volumes ONTAP subscription and the NetApp Intelligent Services (NIS) subscription are available for your AWS account, you can use *Billing preferences* to select which subscription is used for Cloud Volumes ONTAP capacity billing.
 
 NOTE: Billing behavior depends on whether you have existing Cloud Volumes ONTAP systems already running and billed through NIS, or you are deploying new systems after adding the standalone Cloud Volumes ONTAP subscription. For existing systems, adding the standalone subscription does not change billing unless you update *Billing preferences*. For new deployments created after the standalone subscription is available, the standalone subscription is used by default for Cloud Volumes ONTAP capacity billing (Essentials/Freemium), unless you override it in *Billing preferences*.
 

--- a/task-manage-capacity-licenses.adoc
+++ b/task-manage-capacity-licenses.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: task-manage-capacity-licenses.html
-keywords: license, licenses, licensing, capacity license, capacity based license, add license, install license, digital wallet
+keywords: license, licensing, capacity license, capacity based license, add license, install license, digital wallet
 summary: Manage your capacity-based licenses from the NetApp Console to ensure that your NetApp account has enough capacity for your Cloud Volumes ONTAP systems.
 ---
 

--- a/task-manage-capacity-licenses.adoc
+++ b/task-manage-capacity-licenses.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: task-manage-capacity-licenses.html
-keywords: license, licensing, capacity license, capacity based license, add license, install license, digital wallet
+keywords: license, licenses, licensing, capacity license, capacity based license, add license, install license, digital wallet
 summary: Manage your capacity-based licenses from the NetApp Console to ensure that your NetApp account has enough capacity for your Cloud Volumes ONTAP systems.
 ---
 

--- a/task-manage-capacity-licenses.adoc
+++ b/task-manage-capacity-licenses.adoc
@@ -101,6 +101,8 @@ The Console always attempts to charge against a license first. If a license isn'
 
 * If you have a private offer or contract from your cloud provider's marketplace, changing to a charging method that's not included in your contract will result in charging against BYOL (if you purchased a license from NetApp) or PAYGO.
 
+* If you plan to bill Cloud Volumes ONTAP capacity through the standalone Cloud Volumes ONTAP subscription in AWS marketplace, the Cloud Volumes ONTAP system must use a supported capacity-based package (Essentials or Freemium). The Professional package is not supported for the standalone listing and continues to bill through the NIS subscription. After selecting the package you want, use *Billing preferences* in NetApp Console to choose the marketplace subscription used for Cloud Volumes ONTAP billing. 
+
 .Steps
 
 . From the left navigation pane, select *Administration > 	Licenses and subscriptions*.

--- a/task-manage-subscriptions.adoc
+++ b/task-manage-subscriptions.adoc
@@ -26,6 +26,8 @@ include::_include/role-requirement.adoc[]
 
 You can subscribe to a marketplace subscription directly from the Console.
 
+NOTE: For AWS, your account might have more than one NetApp marketplace subscription available. If you associate only the standalone Cloud Volumes ONTAP subscription, you can deploy Cloud Volumes ONTAP using Essentials, but configuring Backup and Recovery requires a different subscription. To choose which subscription is used for Cloud Volumes ONTAP capacity billing (including changing billing for existing systems), go to *Administration > Licenses and subscriptions > Billing preferences*.
+
 .Steps
 
 . From the NetApp Console menu, select *Administration > Licenses and subscriptions*.
@@ -37,8 +39,6 @@ You can subscribe to a marketplace subscription directly from the Console.
 . In the Add Subscription dialog, select a cloud provider.
 
 .. If choosing an AWS subscription, choose whether you want an annual contract or PAYGO subscription.
-
-NOTE: For AWS, your account might have more than one NetApp marketplace subscription available. If you associate only the standalone Cloud Volumes ONTAP subscription, you can deploy Cloud Volumes ONTAP using Essentials, but configuring Backup and Recovery requires a different subscription. To choose which subscription is used for Cloud Volumes ONTAP capacity billing (including changing billing for existing systems), go to *Administration > Licenses and subscriptions > Billing preferences*.
 
 . Select *Add subscription* to navigate to the provider's marketplace and complete the provided steps.
 

--- a/task-manage-subscriptions.adoc
+++ b/task-manage-subscriptions.adoc
@@ -38,6 +38,8 @@ You can subscribe to a marketplace subscription directly from the Console.
 
 .. If choosing an AWS subscription, choose whether you want an annual contract or PAYGO subscription.
 
+NOTE: For AWS, your account might have more than one NetApp marketplace subscription available. If you associate only the standalone Cloud Volumes ONTAP subscription, you can deploy Cloud Volumes ONTAP using Essentials, but configuring Backup and Recovery requires a different subscription. To choose which subscription is used for Cloud Volumes ONTAP capacity billing (including changing billing for existing systems), go to *Administration > Licenses and subscriptions > Billing preferences*.
+
 . Select *Add subscription* to navigate to the provider's marketplace and complete the provided steps.
 
 . When finished at the cloud provider marketplace, return to the Console to complete the process. 


### PR DESCRIPTION
## Summary

Synchronize the public documentation repository with the merged internal `main` changes for BLUEXPDOC-1034.

## Changes

- Preserve the existing public `main` history and commits.
- Add the CVO standalone listing updates from internal `main`.
- Update billing preferences, capacity licenses, and subscriptions documentation.

The synchronization branch was created from public `main` and merged with internal `main` without conflicts. Its final file tree matches internal `main` while retaining the public repository history.